### PR TITLE
Omitir validación del módulo 11 para personas jurídicas

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,11 +34,12 @@ npm install validator-ec
 
 ## Validadores
 
-| Validador                             | Descripción                                                                                                               | Ejemplo                  |
-| ------------------------------------- | ------------------------------------------------------------------------------------------------------------------------- | ------------------------ |
-| `isCedula(cedula: string): boolean`   | Valida una cédula de identidad ecuatoriana. Devuelve `true` si la cédula es válida, de lo contrario `false`.              | `isCedula('1710034065')` |
-| `isRUC(ruc: string): boolean`         | Valida un número de RUC (Registro Único de Contribuyentes). Devuelve `true` si el RUC es válido, de lo contrario `false`. | `isRUC('1790016919001')` |
-| `isZipCode(zipCode: string): boolean` | Valida un código postal ecuatoriano. Devuelve `true` si el código postal es válido, de lo contrario `false`.              | `isZipCode('131401')`    |
+| Validador                                | Descripción                                                                                                               | Ejemplo                             |
+| ---------------------------------------- | ------------------------------------------------------------------------------------------------------------------------- | ----------------------------------- |
+| `isCedula(cedula: string): boolean`      | Valida una cédula de identidad ecuatoriana. Devuelve `true` si la cédula es válida, de lo contrario `false`.              | `isCedula('1710034065')`            |
+| `isRUC(ruc: string): boolean`            | Valida un número de RUC (Registro Único de Contribuyentes). Devuelve `true` si el RUC es válido, de lo contrario `false`. | `isRUC('1790016919001')`            |
+| `isLegalEntityRUC(ruc: string): boolean` | Devuelve `true` si un RUC pertenece a una persona jurídica (tercer dígito igual a 9), de lo contrario `false`.            | `isLegalEntityRuc('0992345678001')` |
+| `isZipCode(zipCode: string): boolean`    | Valida un código postal ecuatoriano. Devuelve `true` si el código postal es válido, de lo contrario `false`.              | `isZipCode('131401')`               |
 
 ## Uso
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "validator-ec",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "type": "module",
   "author": "Victor Bayas",
   "license": "Apache-2.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 import isCedula from "./lib/isCedula";
-import isRUC from "./lib/isRUC";
+import { isRUC, isLegalEntityRUC } from "./lib/isRUC";
 import isZipCode from "./lib/isZipCode";
 
-export { isCedula, isRUC, isZipCode };
+export { isCedula, isRUC, isLegalEntityRUC, isZipCode };

--- a/src/lib/isRUC.ts
+++ b/src/lib/isRUC.ts
@@ -5,9 +5,20 @@ import isCedula from "./isCedula";
  * Valida un RUC ecuatoriano.
  *
  * @param {string} ruc El RUC a validar.
- * @returns {boolean} Devuelve `true` si el RUC es válido, de lo contrario devuelve `false`.
+ * @returns {boolean} Devuelve `true` si el RUC es válido,
+ * de lo contrario devuelve `false`.
+ *
+ * @remarks
+ * De acuerdo a lo dispuesto por el Servicio de Rentas Internas (SRI) [1],
+ * esta función **no aplica** el algoritmo de validación del módulo 11 para
+ * RUCs de personas jurídicas (tercer dígito igual a 9).
+ *
+ * En caso de ser necesario, el SRI recomienda verificar la validez del RUC
+ * a través de sus canales oficiales de consulta pública.
+ *
+ * [1] https://minka.gob.ec/mintel/ge/rutr/gobec_forms/uploads/1ef593d96275a7c07987c5bc043ce654/comunicado_cambio_generacion_RUC.pdf
  */
-export default function isRUC(ruc: string): boolean {
+export function isRUC(ruc: string): boolean {
   // Verificamos que el RUC tenga 13 dígitos
   if (ruc.length !== 13) {
     return false;
@@ -55,21 +66,8 @@ export default function isRUC(ruc: string): boolean {
 
 // Función para validar RUC de personas jurídicas
 function validateLegalEntityRUC(ruc: string): boolean {
-  // Coeficientes para personas jurídicas
-  const coefficients = [4, 3, 2, 7, 6, 5, 4, 3, 2];
-  const baseCode = ruc.substring(0, 9);
-  const validatorDigit = parseInt(ruc[9], 10);
-
-  let sum = 0;
-  for (let i = 0; i < coefficients.length; i++) {
-    const value = parseInt(baseCode[i], 10) * coefficients[i];
-    sum += value;
-  }
-
-  const remainder = sum % 11;
-  const result = remainder === 0 ? 0 : 11 - remainder;
-
-  return result === validatorDigit;
+  // Se omite la validación del módulo 11 de acuerdo a lo dispuesto por el SRI
+  return true;
 }
 
 // Función para validar RUC de entidades públicas
@@ -89,4 +87,15 @@ function validatePublicEntityRUC(ruc: string): boolean {
   const result = remainder === 0 ? 0 : 11 - remainder;
 
   return result === validatorDigit;
+}
+
+/**
+ * Determina si un RUC pertenece a una persona jurídica (tercer dígito igual a 9).
+ *
+ * @param {string} ruc El RUC a comprobar.
+ * @returns {boolean} Devuelve `true` si el RUC pertenece a una persona jurídica,
+ * de lo contrario devuelve `false`.
+ */
+export function isLegalEntityRUC(ruc: string): boolean {
+  return ruc.length === 13 && ruc[2] === "9";
 }

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { isCedula, isRUC, isZipCode } from "../src";
+import { isLegalEntityRUC } from "../src/lib/isRUC";
 
 describe("Validador isCedula", () => {
   it("debería retornar true para una cédula válida", () => {
@@ -73,6 +74,18 @@ describe("Validador isRUC", () => {
     expect(isRUC("0990004196001")).toBe(true);
     expect(isRUC("0190072002001")).toBe(true);
     expect(isRUC("1390012949001")).toBe(true);
+  });
+
+  // Prueba para RUCs de personas jurídicas que no pasarían la validación del módulo 11
+  // pero que son válidos según lo dispuesto por el SRI (ya no se valida con módulo 11)
+  it("debería retornar true para RUCs de personas jurídicas sin validación de módulo 11", () => {
+    expect(isRUC("1791234567001")).toBe(true);
+    expect(isRUC("0992345678001")).toBe(true);
+    expect(isRUC("1793456789001")).toBe(true);
+  });
+
+  it("debería retornar true si el RUC pertenece a una persona jurídica", () => {
+    expect(isLegalEntityRUC("1790016919001")).toBe(true);
   });
 
   it("debería retornar true para un RUC válido de entidad pública", () => {


### PR DESCRIPTION
## Descripción

Este PR ajusta la lógica de validación del RUC para personas jurídicas para alinearla con la disposición oficial del Servicio de Rentas Internas (SRI) [1].

El cambio principal consiste en **omitir la validación del algoritmo módulo 11** para los RUCs pertenecientes a personas jurídicas (aquellos cuyo tercer dígito es '9'). Esto sigue la recomendación explícita del SRI, ya que sus procesos internos de generación pueden resultar en RUCs válidos que no pasarían la comprobación tradicional del módulo 11.

Fixes https://github.com/bayasdev/validator-ec/issues/4

## Cambios Realizados

*   Se modificó la función `isRUC` para **omitir la validación del módulo 11** específicamente para los RUCs identificados como pertenecientes a personas jurídicas. Estos RUCs ahora se consideran válidos por `isRUC` si cumplen los criterios básicos (longitud 13, numérico, código de provincia correcto, sufijo '001').
*   Se introdujo una nueva función auxiliar `isLegalEntityRUC(ruc: string): boolean`.
*   Se añadieron nuevos casos de prueba para verificar la nueva lógica y la función auxiliar.
*   Se actualizó el README y se incrementó la versión del paquete a `1.3.0`.

## Uso Recomendado de `isLegalEntityRUC`

La nueva función `isLegalEntityRUC` está diseñada para ayudar a implementar la estrategia de validación recomendada por el SRI:

1.  Puedes usar `isLegalEntityRUC(ruc)` para determinar si un RUC pertenece a una persona jurídica.
2.  **Si `isLegalEntityRUC` devuelve `true`**, y necesitas una confirmación de validez más allá de los chequeos básicos (longitud, formato), **la recomendación del SRI es validar ese RUC directamente contra sus servicios web oficiales**.
3.  La función `isRUC` de esta librería ya **no** intentará validar el dígito verificador para estos casos, simplemente confirmará el formato general.

## Motivo del Cambio

Asegurar que la librería `validator-ec` refleje con precisión las reglas de validación oficiales y actuales definidas por el SRI, evitando que RUCs válidos de personas jurídicas sean marcados incorrectamente como inválidos. Se facilita la implementación de la estrategia de validación sugerida por el SRI mediante la función `isLegalEntityRUC`.

## Enlaces Relacionados

[1] Comunicación SRI (Comunicado Registro Único de Contribuyentes - RUC): https://minka.gob.ec/mintel/ge/rutr/gobec_forms/uploads/1ef593d96275a7c07987c5bc043ce654/comunicado_cambio_generacion_RUC.pdf

## Pruebas

*   Las pruebas existentes pasan.
*   Se han añadido y pasan nuevas pruebas que cubren específicamente la lógica actualizada para los RUCs de personas jurídicas y la función `isLegalEntityRUC`.
